### PR TITLE
Add example, fix CBOR decoding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ func attest(nonce, userData, publicKey []byte) ([]byte, error) {
 }
 ```
 
+There's a full example in `example/attestation`.
+
 ## Reference Implementation
 
 This implementation is based on the [Nitro Enclaves SDK][nitro-enclaves-sdk]

--- a/example/attestation/Dockerfile
+++ b/example/attestation/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.17.2-buster
+
+WORKDIR /
+
+RUN mkdir -p source
+
+COPY . ./source/
+
+WORKDIR source/example/attestation
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o enclave main.go
+
+FROM scratch
+
+WORKDIR /
+
+COPY --from=0 /source/example/attestation/enclave ./
+
+CMD ["/enclave"]
+

--- a/example/attestation/README.md
+++ b/example/attestation/README.md
@@ -1,0 +1,36 @@
+# NSM Attestation Example
+
+This is a simple example that shows how you can get the attestation from a
+Nitro Enclave.
+
+Make sure you've read the AWS Nitro Enclaves guide.
+
+All commands should be run in the root of the project, not the directory where
+this README resides.
+
+First build a Docker image:
+
+```bash
+docker build -t nsm-example -f example/attestation/Dockerfile .
+```
+
+Then build a Nitro EIF file:
+
+```bash
+nitro-cli build-enclave --docker-uri nsm-example --output-file nsm-example.eif
+```
+
+Then run an enclave:
+
+```bash
+sudo nitro-cli run-enclave --eif-path nsm-example.eif --cpu-count 2 --memory 1024 --debug-mode
+```
+
+Record the enclave ID as returned by the above command, and execute:
+
+```bash
+sudo nitro-cli console --enclave-id <ENCLAVE-ID>
+```
+
+You should be able to see a Base64 encoded version of the returned attestation
+in the console output.

--- a/example/attestation/main.go
+++ b/example/attestation/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/hf/nsm"
+	"github.com/hf/nsm/request"
+	"time"
+)
+
+func attest(nonce, userData, publicKey []byte) ([]byte, error) {
+	sess, err := nsm.OpenDefaultSession()
+	defer sess.Close()
+
+	if nil != err {
+		return nil, err
+	}
+
+	res, err := sess.Send(&request.Attestation{
+		Nonce:     nonce,
+		UserData:  userData,
+		PublicKey: publicKey,
+	})
+	if nil != err {
+		return nil, err
+	}
+
+	if "" != res.Error {
+		return nil, errors.New(string(res.Error))
+	}
+
+	if nil == res.Attestation || nil == res.Attestation.Document {
+		return nil, errors.New("NSM device did not return an attestation")
+	}
+
+	return res.Attestation.Document, nil
+}
+
+func main() {
+	att, err :=
+		attest(
+			[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+			[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+			[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		)
+
+	fmt.Printf("attestation %v %v\n", base64.StdEncoding.EncodeToString(att), err)
+
+	time.Sleep(5 * time.Minute)
+}

--- a/response/response.go
+++ b/response/response.go
@@ -116,14 +116,19 @@ func (res *Response) UnmarshalCBOR(data []byte) error {
 		res.Attestation = possiblyMap.Attestation
 		res.GetRandom = possiblyMap.GetRandom
 		res.Error = possiblyMap.Error
+
+		return nil
 	}
 
-	if "LockPCR" == possiblyString {
+	switch possiblyString {
+	case "LockPCR":
 		res.LockPCR = &LockPCR{}
-	} else if "LockPCRs" == possiblyString {
+
+	case "LockPCRs":
 		res.LockPCRs = &LockPCRs{}
-	} else {
-		return fmt.Errorf("Unknown response string-like value %v", possiblyString)
+
+	default:
+		return fmt.Errorf("Unknown NSM response with string-like value %q", possiblyString)
 	}
 
 	return nil


### PR DESCRIPTION
Adds a full example for getting the attestation out.

It also fixes an issue with the decoding of the NSM driver response as a CBOR message.